### PR TITLE
Fixed Coveralls README status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # apig
 
 [![CircleCI](https://circleci.com/gh/CraftTurf/apig.svg?style=svg)](https://circleci.com/gh/CraftTurf/apig)
-[![Coverage Status](https://coveralls.io/repos/github/jabdul/apig/badge.svg?branch=master)](https://coveralls.io/github/jabdul/apig?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/CraftTurf/apig/badge.svg)](https://coveralls.io/github/CraftTurf/apig?branch=master)
 
 apig is the command-line interface tool for [crud-api](https://github.com/jabdul/crud-api).
 


### PR DESCRIPTION
Coveralls README status badge was pointing to the wrong repo url causing coverage status to be unknown 
<img width="198" alt="image" src="https://user-images.githubusercontent.com/14836948/71976441-9fce7b00-3216-11ea-8726-4a47e360e4ef.png">
