### PR TITLE
Faster queries with dehydrated objects

### DIFF
--- a/scaffold/endpoint/persistence/mongoose/{{{scaffold_entity_capitalise}}}/queries.js
+++ b/scaffold/endpoint/persistence/mongoose/{{{scaffold_entity_capitalise}}}/queries.js
@@ -25,11 +25,12 @@ const findAll = async ({ payload }) => {{{scaffold_entity_capitalise}}}.paginate
   {
     page: payload.pageid,
     limit: payload.limit,
+    lean: true,
     sort: { 'meta.created': 'desc', 'meta.updated': 'desc' }
   }
 );
 
-const findById = async ({ payload }) => {{{scaffold_entity_capitalise}}}.findOne({ uuid: payload.uuid });
+const findById = async ({ payload }) => {{{scaffold_entity_capitalise}}}.findOne({ uuid: payload.uuid }).lean();
 
 const removeById = async ({ payload }) => {{{scaffold_entity_capitalise}}}.updateOne(
   { uuid: payload.uuid },


### PR DESCRIPTION
## [As seen on the official documentation](https://mongoosejs.com/docs/tutorials/lean.html)
The `lean` option tells Mongoose to skip hydrating the result documents. This makes queries faster and less memory intensive, but the result documents are plain old JavaScript objects (POJOs), not Mongoose documents. In this tutorial, you'll learn more about the tradeoffs of using lean()