### PR TITLE
Nodemon server restart error fix

### DIFF
--- a/scaffold/service/nodemon.json
+++ b/scaffold/service/nodemon.json
@@ -1,0 +1,8 @@
+{
+  "signal": "SIGTERM",
+  "env": {
+    "NODE_ENV": "development"
+  },
+  "ext": "js",
+  "exec": "babel-node -- src/index.js"
+}

--- a/scaffold/service/package.json.replace
+++ b/scaffold/service/package.json.replace
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "babel src -d lib --ignore *.test*.js",
-    "dev": "nodemon --delay 250ms --exec NODE_ENV=development babel-node -- src/index.js",
+    "dev": "nodemon",
     "dump": "babel-node -- src/persistence/mongoose/backup.js",
     "clean": "concurrently 'rimraf node_modules' 'rimraf lib/*' 'yarn cache clean'",
     "flow": "flow check --all",

--- a/scaffold/service/package.json.replace
+++ b/scaffold/service/package.json.replace
@@ -63,7 +63,7 @@
     "flow-bin": "0.78.0",
     "flow-typed": "2.5.1",
     "jest": "23.5.0",
-    "nodemon": "1.18.3",
+    "nodemon": "^2.0.1",
     "precommit-hook-eslint": "3.0.0"
   },
   "dependencies": {

--- a/scaffold/service/src/README.md
+++ b/scaffold/service/src/README.md
@@ -1,2 +1,0 @@
-#Endpoints
-endpoint definition goes here. Use the `aig` tool to generate skeleton.


### PR DESCRIPTION
This is a tested fix for the famous `[nodemon] Error: listen EADDRINUSE: address already in use` error that have plagued our services.

This build on the awesome config from **Victor@CTT**. I made this changes
- [x] Upgraded `nodemon` version
- [x] Send `SIGTERM` signal to app for graceful shutdown
- [x] Remove delay since app will clean up before starting back up
- [x] Removed excessive `README.md` in service scaffold 